### PR TITLE
[FEAT] 상품 관련 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,8 @@ dependencies {
 	// 테스트 검증
 	testImplementation 'org.assertj:assertj-core:3.23.1'
 	testImplementation 'com.h2database:h2'
-	
+
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,12 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+
+	// 테스트 검증
+	testImplementation 'org.assertj:assertj-core:3.23.1'
+	testImplementation 'com.h2database:h2'
+	
 }
 
 tasks.named('test') {

--- a/src/main/java/com/pedalgenie/pedalgenieback/PedalGenieBackApplication.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/PedalGenieBackApplication.java
@@ -2,9 +2,7 @@ package com.pedalgenie.pedalgenieback;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @EnableJpaAuditing
 @SpringBootApplication

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/category/dto/CategoryProductsRequest.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/category/dto/CategoryProductsRequest.java
@@ -1,0 +1,6 @@
+package com.pedalgenie.pedalgenieback.domain.category.dto;
+
+public record CategoryProductsRequest(
+        Long categoryId
+) {
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/category/dto/CategoryProductsResponse.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/category/dto/CategoryProductsResponse.java
@@ -1,0 +1,17 @@
+package com.pedalgenie.pedalgenieback.domain.category.dto;
+
+import com.pedalgenie.pedalgenieback.domain.product.entity.Product;
+
+public record CategoryProductsResponse(
+        String name,
+        Double rentPricePerDay,
+        String shopName
+) {
+    public static CategoryProductsResponse from(final Product product){
+        return new CategoryProductsResponse(
+                product.getName(),
+                product.getRentPricePerDay(),
+                product.getShop().getShopname()
+        );
+    }
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/category/entity/Category.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/category/entity/Category.java
@@ -1,0 +1,28 @@
+package com.pedalgenie.pedalgenieback.domain.category.entity;
+
+import com.pedalgenie.pedalgenieback.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Category extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
+    private Long id;
+
+    @NotNull
+    private String name;
+
+    @Builder
+    public Category(Long id, String name){
+        this.id=id;
+        this.name=name;
+    }
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,9 @@
+package com.pedalgenie.pedalgenieback.domain.category.repository;
+
+import com.pedalgenie.pedalgenieback.domain.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.nio.file.LinkOption;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/category/repository/CategoryRepository.java
@@ -3,7 +3,6 @@ package com.pedalgenie.pedalgenieback.domain.category.repository;
 import com.pedalgenie.pedalgenieback.domain.category.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.nio.file.LinkOption;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 }

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/member/service/MemberService.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/member/service/MemberService.java
@@ -2,8 +2,8 @@ package com.pedalgenie.pedalgenieback.domain.member.service;
 
 import com.pedalgenie.pedalgenieback.domain.member.dto.MemberLoginRequestDto;
 import com.pedalgenie.pedalgenieback.domain.member.dto.MemberLoginResponseDto;
-import com.pedalgenie.pedalgenieback.domain.member.dto.MemberResponseDto;
 import com.pedalgenie.pedalgenieback.domain.member.dto.MemberRegisterRequestDto;
+import com.pedalgenie.pedalgenieback.domain.member.dto.MemberResponseDto;
 import com.pedalgenie.pedalgenieback.domain.member.entity.Member;
 import com.pedalgenie.pedalgenieback.domain.member.entity.MemberRole;
 import com.pedalgenie.pedalgenieback.domain.member.repository.MemberRepository;
@@ -21,8 +21,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/request/FilterRequest.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/request/FilterRequest.java
@@ -1,0 +1,23 @@
+package com.pedalgenie.pedalgenieback.domain.product.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record FilterRequest(
+        Boolean isRentable,
+        Boolean isPurchasable,
+        Boolean isDemoable,
+
+        @Size(max = 10, message = "카테고리는 최대 10개까지 선택할 수 있습니다.")
+        List<Long> subCategoryIds
+) {
+    public static FilterRequest of(
+            Boolean isRentable,
+            Boolean isPurchasable,
+            Boolean isDemoable,
+            List<Long> subCategoryIds
+    ){
+        return new FilterRequest(isRentable,isPurchasable,isDemoable, subCategoryIds);
+    }
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/request/ProductCreateRequestDto.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/request/ProductCreateRequestDto.java
@@ -1,0 +1,24 @@
+package com.pedalgenie.pedalgenieback.domain.product.dto.request;
+
+import com.pedalgenie.pedalgenieback.domain.product.entity.Product;
+import com.pedalgenie.pedalgenieback.domain.shop.entity.Shop;
+import com.pedalgenie.pedalgenieback.domain.subcategory.entity.SubCategory;
+import lombok.Builder;
+
+@Builder
+public record ProductCreateRequestDto(String name, String description, Double rentPricePerDay
+, Integer rentQuantityPerDay, Double price){
+
+    public Product toEntity(Shop shop, SubCategory subCategory){
+        return Product.builder()
+                .name(name)
+                .rentPricePerDay(rentPricePerDay)
+                .rentQuantityPerDay(rentQuantityPerDay)
+                .price(price)
+                .shop(shop)
+                .subCategory(subCategory)
+                .build();
+
+    }
+
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/FilterMetadataResponse.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/FilterMetadataResponse.java
@@ -1,0 +1,15 @@
+package com.pedalgenie.pedalgenieback.domain.product.dto.response;
+
+import java.util.List;
+
+public record FilterMetadataResponse(
+        List<String> keywords,
+        FilterResponse filters
+) {
+    public static FilterMetadataResponse of(FilterResponse filterResponse){
+        return new FilterMetadataResponse(
+                List.of("대여 가능", "시연 가능", "구매 가능"),
+                filterResponse
+        );
+    }
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/FilterResponse.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/FilterResponse.java
@@ -1,0 +1,18 @@
+package com.pedalgenie.pedalgenieback.domain.product.dto.response;
+
+import java.util.List;
+
+public record FilterResponse(
+        List<Boolean> rentOptions,
+        List<Boolean> purchaseOptions,
+        List<Boolean> demoOptions
+
+) {
+    public static FilterResponse of(){
+        return new FilterResponse(
+                List.of(true, false),
+                List.of(true, false),
+                List.of(true, false)
+        );
+    }
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/GetProductQueryResponse.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/GetProductQueryResponse.java
@@ -1,0 +1,12 @@
+package com.pedalgenie.pedalgenieback.domain.product.dto.response;
+
+public record GetProductQueryResponse( // 쿼리 결과 전용
+
+        String name,
+        String shopName,
+        Double rentPricePerDay
+) {
+    public GetProductQueryResponse{
+
+    }
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/GetProductResponse.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/GetProductResponse.java
@@ -1,0 +1,28 @@
+package com.pedalgenie.pedalgenieback.domain.product.dto.response;
+
+import com.pedalgenie.pedalgenieback.domain.product.entity.Product;
+
+// 상품 상세 조회 dto
+public record GetProductResponse(
+        String name,
+        String shopName,
+        String businessHours,
+        Double price,
+        Double rentPricePerDay,
+        Boolean isRentable,
+        Boolean isPurchasable,
+        Boolean isDemoable
+) {
+    public static GetProductResponse of(Product product){
+        return new GetProductResponse(
+                product.getName(),
+                product.getShop().getShopname(),
+                product.getShop().getBusinessHours(),
+                product.getPrice(),
+                product.getRentPricePerDay(),
+                product.getIsRentable(),
+                product.getIsPurchasable(),
+                product.getIsDemoable()
+        );
+    }
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/GetProductsResponse.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/GetProductsResponse.java
@@ -1,0 +1,15 @@
+package com.pedalgenie.pedalgenieback.domain.product.dto.response;
+
+import java.util.List;
+
+public record GetProductsResponse( // 전체 응답 포장
+        List<ProductResponse> products
+) {
+    public static GetProductsResponse from(List<GetProductQueryResponse> products){
+        List<ProductResponse> productResponses = products.stream()
+                .map(ProductResponse::from)
+                .toList();
+
+        return new GetProductsResponse(productResponses);
+    }
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/ProductResponse.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/ProductResponse.java
@@ -1,0 +1,18 @@
+package com.pedalgenie.pedalgenieback.domain.product.dto.response;
+
+public record ProductResponse( // api 응답 전용
+                               String name,
+                               Double rentPricePerDay,
+                               String shopName
+) {
+
+    public static ProductResponse from(final GetProductQueryResponse product){
+        return new ProductResponse(
+                product.name(),
+                product.rentPricePerDay(),
+                product.shopName()
+        );
+
+    }
+
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/entity/Product.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/entity/Product.java
@@ -1,0 +1,52 @@
+package com.pedalgenie.pedalgenieback.domain.product.entity;
+
+import com.pedalgenie.pedalgenieback.domain.shop.entity.Shop;
+import com.pedalgenie.pedalgenieback.domain.subcategory.entity.SubCategory;
+import com.pedalgenie.pedalgenieback.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Product extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_id")
+    private Long id;
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    private String description;
+
+    @NotNull
+    private double rentPricePerDay;
+
+    @NotNull
+    private int rentQuantityPerDay;
+
+    @ManyToOne
+    private Shop shop;
+
+    @ManyToOne
+    @JoinColumn(name = "subcategory_id") // 외래키 컬럼명. 변경할까?
+    private SubCategory subCategory;
+
+    @Builder
+    public Product(Long id, String name, String description, double rentPricePerDay, int
+            rentQuantityPerDay, Shop shop, SubCategory subCategory){
+        this.id=id;
+        this.name=name;
+        this.description=description;
+        this.rentPricePerDay=rentPricePerDay;
+        this.rentQuantityPerDay=rentQuantityPerDay;
+        this.shop=shop;
+        this.subCategory=subCategory;
+    }
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/entity/Product.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/entity/Product.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+
 @Entity
 @NoArgsConstructor
 @Getter
@@ -23,30 +24,41 @@ public class Product extends BaseTimeEntity {
     private String name;
 
     @NotNull
-    private String description;
+    private Double rentPricePerDay;
 
     @NotNull
-    private double rentPricePerDay;
+    private Integer rentQuantityPerDay;
 
     @NotNull
-    private int rentQuantityPerDay;
+    private Double price;
+
+    private Boolean isRentable;
+
+    private Boolean isPurchasable;
+
+    private Boolean isDemoable;
 
     @ManyToOne
+    @JoinColumn(name = "shop_id")
     private Shop shop;
 
     @ManyToOne
-    @JoinColumn(name = "subcategory_id") // 외래키 컬럼명. 변경할까?
+    @JoinColumn(name = "subCategory_id")
     private SubCategory subCategory;
 
     @Builder
-    public Product(Long id, String name, String description, double rentPricePerDay, int
-            rentQuantityPerDay, Shop shop, SubCategory subCategory){
+    public Product(Long id, String name, Double rentPricePerDay,
+                   Integer rentQuantityPerDay, Double price, Shop shop, SubCategory subCategory,
+                   Boolean isRentable, Boolean isPurchasable, Boolean isDemoable){
         this.id=id;
         this.name=name;
-        this.description=description;
         this.rentPricePerDay=rentPricePerDay;
         this.rentQuantityPerDay=rentQuantityPerDay;
+        this.price=price;
         this.shop=shop;
         this.subCategory=subCategory;
+        this.isRentable=isRentable;
+        this.isPurchasable=isPurchasable;
+        this.isDemoable=isDemoable;
     }
 }

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/entity/ProductDescription.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/entity/ProductDescription.java
@@ -1,0 +1,26 @@
+package com.pedalgenie.pedalgenieback.domain.product.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ProductDescription {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id", nullable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    private String url;
+
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Product product;
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/entity/ProductImage.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/entity/ProductImage.java
@@ -1,0 +1,26 @@
+package com.pedalgenie.pedalgenieback.domain.product.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ProductImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id", nullable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    private String url;
+
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Product product;
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/presentation/ProductController.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/presentation/ProductController.java
@@ -1,0 +1,81 @@
+package com.pedalgenie.pedalgenieback.domain.product.presentation;
+
+import com.pedalgenie.pedalgenieback.domain.category.dto.CategoryProductsRequest;
+import com.pedalgenie.pedalgenieback.domain.category.dto.CategoryProductsResponse;
+import com.pedalgenie.pedalgenieback.domain.product.dto.request.FilterRequest;
+import com.pedalgenie.pedalgenieback.domain.product.dto.response.FilterMetadataResponse;
+import com.pedalgenie.pedalgenieback.domain.product.dto.response.FilterResponse;
+import com.pedalgenie.pedalgenieback.domain.product.dto.response.GetProductResponse;
+import com.pedalgenie.pedalgenieback.domain.product.dto.response.GetProductsResponse;
+import com.pedalgenie.pedalgenieback.domain.product.service.ProductQueryService;
+import com.pedalgenie.pedalgenieback.domain.subcategory.dto.FilterSubCategoryResponse;
+import com.pedalgenie.pedalgenieback.global.ResponseTemplate;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/products")
+public class ProductController {
+
+    private final ProductQueryService productQueryService;
+
+    @Operation(summary = "옵션 따라 모든 상품 조회")
+    @GetMapping
+    public ResponseEntity<GetProductsResponse> getProducts(
+            @RequestParam(required = false) Boolean isRentable,
+            @RequestParam(required = false) Boolean isPurchasable,
+            @RequestParam(required = false) Boolean isDemoable,
+            @RequestParam(required = false) List<Long> subCategoryIds
+    ){
+        FilterRequest filterRequest = FilterRequest.of(
+                isRentable,
+                isPurchasable,
+                isDemoable,
+                subCategoryIds);
+
+        return ResponseEntity.ok(productQueryService.getProductsByFilters(filterRequest));
+    }
+
+    @Operation(summary = "필터 옵션 조회")
+    @GetMapping("/filters")
+    public ResponseEntity<ResponseTemplate<FilterMetadataResponse>> getFilterMetadata(){
+        FilterResponse filterResponse = productQueryService.getMetadataForFilter();
+        FilterMetadataResponse filterMetadataResponse = FilterMetadataResponse.of(filterResponse);
+        return  ResponseTemplate.createTemplate(HttpStatus.OK, true,
+                "필터 옵션 조회 성공", filterMetadataResponse);
+    }
+
+    @Operation(summary = "카테고리 옵션 조회")
+    @GetMapping("/subcategories")
+    public ResponseEntity<ResponseTemplate<FilterSubCategoryResponse>> getSubCategories(){
+        FilterSubCategoryResponse subCategoryProductsResponse = productQueryService.getMetaForSubCategory();
+        return ResponseTemplate.createTemplate(HttpStatus.OK, true,
+                "카테고리 옵션 조회 성공", subCategoryProductsResponse);
+    }
+
+    @Operation(summary = "상품 상세 조회")
+    @GetMapping("/{id}")
+    public ResponseEntity<ResponseTemplate<GetProductResponse>> getProduct(@PathVariable Long id){
+        GetProductResponse getProductResponse = productQueryService.getProductResponse(id);
+        return ResponseTemplate.createTemplate(HttpStatus.OK,true,
+                "상품 상세 조회 성공", getProductResponse);
+    }
+
+    @Operation(summary ="상위 카테고리 내 상품 조회 ")
+    @PostMapping
+    public ResponseEntity<ResponseTemplate<List<CategoryProductsResponse>>> getProductsByCategory(
+            @RequestBody final CategoryProductsRequest request){
+        List<CategoryProductsResponse> responses = productQueryService.getProductByCategory(request);
+
+        return ResponseTemplate.createTemplate(HttpStatus.OK, true,
+                "상위 카테고리 내 상품 조회 성공",responses);
+    }
+
+
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/repository/ProductQueryRepository.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/repository/ProductQueryRepository.java
@@ -1,0 +1,9 @@
+package com.pedalgenie.pedalgenieback.domain.product.repository;
+
+import com.pedalgenie.pedalgenieback.domain.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductQueryRepository extends JpaRepository<Product, Long>, ProductQueryRepositoryCustom{
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/repository/ProductQueryRepositoryCustom.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/repository/ProductQueryRepositoryCustom.java
@@ -1,0 +1,20 @@
+package com.pedalgenie.pedalgenieback.domain.product.repository;
+
+import com.pedalgenie.pedalgenieback.domain.product.dto.response.GetProductQueryResponse;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface ProductQueryRepositoryCustom {
+
+    @Query("SELECT p FROM Product p WHERE p.isRentable = :isRentable " +
+            "AND p.isPurchasable = :isPurchasable " +
+            "AND p.isDemoable = :isDemoable " +
+            "AND p.subCategory.id IN :subCategoryIds")
+    List<GetProductQueryResponse> findPagingProducts(
+            Boolean isRentable,
+            Boolean isPurchasable,
+            Boolean isDemoable,
+            List<Long> subCategoryIds
+    );
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/repository/ProductRepository.java
@@ -1,0 +1,29 @@
+package com.pedalgenie.pedalgenieback.domain.product.repository;
+
+import com.pedalgenie.pedalgenieback.domain.product.entity.Product;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    // 특정 하위 카테고리에 속한 상품 조회
+    List<Product> findBySubCategoryId(Long id);
+
+    // 특정 카테고리에 속한 상품 조회
+//    @EntityGraph(attributePaths = "subCategory.category")
+    @Query("SELECT p FROM Product p " +
+            "JOIN FETCH p.subCategory sc " +
+            "JOIN FETCH sc.category c " +
+            "WHERE c.id = :id")
+    List<Product> findAllBySubCategoryCategoryId(@Param("id")Long id);
+
+    // 대여 가능한 악기만 조회? - 가능여부 필드가 아직 없다.
+    // 시연 가능한 악기만 조회?
+
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/repository/ProductRepository.java
@@ -2,7 +2,6 @@ package com.pedalgenie.pedalgenieback.domain.product.repository;
 
 import com.pedalgenie.pedalgenieback.domain.product.entity.Product;
 import io.lettuce.core.dynamic.annotation.Param;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -13,17 +12,16 @@ import java.util.List;
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
     // 특정 하위 카테고리에 속한 상품 조회
-    List<Product> findBySubCategoryId(Long id);
+    @Query("select distinct p from Product p join fetch p.subCategory " +
+            "where p.subCategory.id = :id")
+    List<Product> findBySubCategoryId(@Param("id")Long id);
 
     // 특정 카테고리에 속한 상품 조회
-//    @EntityGraph(attributePaths = "subCategory.category")
     @Query("SELECT p FROM Product p " +
             "JOIN FETCH p.subCategory sc " +
             "JOIN FETCH sc.category c " +
             "WHERE c.id = :id")
     List<Product> findAllBySubCategoryCategoryId(@Param("id")Long id);
 
-    // 대여 가능한 악기만 조회? - 가능여부 필드가 아직 없다.
-    // 시연 가능한 악기만 조회?
 
 }

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/service/ProductQueryService.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/service/ProductQueryService.java
@@ -1,0 +1,90 @@
+package com.pedalgenie.pedalgenieback.domain.product.service;
+
+import com.pedalgenie.pedalgenieback.domain.category.dto.CategoryProductsRequest;
+import com.pedalgenie.pedalgenieback.domain.category.dto.CategoryProductsResponse;
+import com.pedalgenie.pedalgenieback.domain.category.entity.Category;
+import com.pedalgenie.pedalgenieback.domain.category.repository.CategoryRepository;
+import com.pedalgenie.pedalgenieback.domain.product.dto.request.FilterRequest;
+import com.pedalgenie.pedalgenieback.domain.product.dto.response.FilterResponse;
+import com.pedalgenie.pedalgenieback.domain.product.dto.response.GetProductQueryResponse;
+import com.pedalgenie.pedalgenieback.domain.product.dto.response.GetProductResponse;
+import com.pedalgenie.pedalgenieback.domain.product.dto.response.GetProductsResponse;
+import com.pedalgenie.pedalgenieback.domain.product.entity.Product;
+import com.pedalgenie.pedalgenieback.domain.product.repository.ProductQueryRepositoryCustom;
+import com.pedalgenie.pedalgenieback.domain.product.repository.ProductRepository;
+import com.pedalgenie.pedalgenieback.domain.subcategory.dto.FilterSubCategoryResponse;
+import com.pedalgenie.pedalgenieback.domain.subcategory.entity.SubCategory;
+import com.pedalgenie.pedalgenieback.domain.subcategory.repository.SubcategoryRepository;
+import com.pedalgenie.pedalgenieback.global.exception.CustomException;
+import com.pedalgenie.pedalgenieback.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductQueryService {
+
+    private final ProductRepository productRepository;
+    private final SubcategoryRepository subcategoryRepository;
+    private final ProductQueryRepositoryCustom productQueryRepository;
+    private final CategoryRepository categoryRepository;
+
+    // 특정 상위 카테고리의 상품 조회
+    public List<CategoryProductsResponse> getProductByCategory(final CategoryProductsRequest request){
+        final Category findCategory = getCategory(request.categoryId());
+
+        final List<Product> products = productRepository.findAllBySubCategoryCategoryId(findCategory.getId());
+
+        return products.stream()
+                .map(CategoryProductsResponse::from)
+                .toList();
+    }
+
+    private Category getCategory(final Long categoryId){
+        return categoryRepository.findById(categoryId)
+                .orElseThrow(()->new CustomException(ErrorCode.NOT_FOUND_CATEGORY));
+    }
+
+    // 필터 조건에 따른 상품 조회
+//    @Trace(resourceName = "상품 페이징 조회")
+    public GetProductsResponse getProductsByFilters(FilterRequest filterDto){
+        return GetProductsResponse.from(
+                getPagingProducts(filterDto)
+        );
+    }
+
+    public List<GetProductQueryResponse> getPagingProducts(FilterRequest filterDto){
+        return productQueryRepository.findPagingProducts(
+                filterDto.isRentable(),
+                filterDto.isPurchasable(),
+                filterDto.isDemoable(),
+                filterDto.subCategoryIds()
+        );
+    }
+
+    // 필터 옵션 조회
+    public FilterResponse getMetadataForFilter(){
+        return FilterResponse.of();
+    }
+
+    // 카테고리 옵션 조회
+    public FilterSubCategoryResponse getMetaForSubCategory(){
+        List<SubCategory> subCategories = subcategoryRepository.findAll();
+        return FilterSubCategoryResponse.of(subCategories);
+    }
+
+    // 상품 상세 조회
+    public GetProductResponse getProductResponse(Long id){
+        Product product = productRepository.findById(id)
+                .orElseThrow(()-> new CustomException(ErrorCode.NOT_FOUND_PRODUCT));
+
+        return GetProductResponse.of(product);
+    }
+
+
+
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/service/ProductService.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/service/ProductService.java
@@ -1,0 +1,47 @@
+package com.pedalgenie.pedalgenieback.domain.product.service;
+
+import com.pedalgenie.pedalgenieback.domain.product.dto.request.ProductCreateRequestDto;
+import com.pedalgenie.pedalgenieback.domain.product.entity.Product;
+import com.pedalgenie.pedalgenieback.domain.product.repository.ProductRepository;
+import com.pedalgenie.pedalgenieback.domain.shop.entity.Shop;
+import com.pedalgenie.pedalgenieback.domain.shop.repository.ShopRepository;
+import com.pedalgenie.pedalgenieback.domain.subcategory.entity.SubCategory;
+import com.pedalgenie.pedalgenieback.domain.subcategory.repository.SubcategoryRepository;
+import com.pedalgenie.pedalgenieback.global.exception.CustomException;
+import com.pedalgenie.pedalgenieback.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProductService {
+
+    private final ProductRepository productRepository;
+    private final ShopRepository shopRepository;
+    private final SubcategoryRepository subcategoryRepository;
+
+    public void createProduct(final ProductCreateRequestDto request, final String shopname, final Long subCategoryId){
+        final Shop shop = shopRepository.findByShopname(shopname)
+                .orElseThrow(()-> new CustomException(ErrorCode.NOT_FOUND_SHOP_NAME));
+
+        final SubCategory subCategory = getSubCategory(subCategoryId);
+
+        final Product product = request.toEntity(shop, subCategory);
+        productRepository.save(product);
+
+    }
+
+    private SubCategory getSubCategory(final Long subCategoryId){
+        return subcategoryRepository.findById(subCategoryId)
+                .orElseThrow(()-> new CustomException(ErrorCode.NOT_FOUND_SUBCATEGORY));
+    }
+
+    public void updateProduct(Long id){
+
+    }
+
+
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/entity/Shop.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/entity/Shop.java
@@ -4,19 +4,21 @@ import com.pedalgenie.pedalgenieback.global.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
+@Getter
 public class Shop extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "shop_id")
-    private Long shopId;
+    private Long id;
 
     @NotNull
-    private String name;
+    private String shopname;
 
     @NotNull
     private String address;
@@ -25,16 +27,19 @@ public class Shop extends BaseTimeEntity {
     private String contactNumber;
 
     @NotNull
-    private int demoQuantityPerDay;
+    private Integer demoQuantityPerDay;
 
-    // businessHours
+    @NotNull
+    private String businessHours;
 
     @Builder
-    public Shop(Long shopId, String name, String address, String contactNumber, int demoQuantityPerDay){
-        this.shopId=shopId;
-        this.name=name;
+    public Shop(Long id, String name, String address,
+                String contactNumber, Integer demoQuantityPerDay, String businessHours){
+        this.id= id;
+        this.shopname =name;
         this.address=address;
         this.contactNumber=contactNumber;
         this.demoQuantityPerDay=demoQuantityPerDay;
+        this.businessHours=businessHours;
     }
 }

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/entity/Shop.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/entity/Shop.java
@@ -1,0 +1,40 @@
+package com.pedalgenie.pedalgenieback.domain.shop.entity;
+
+import com.pedalgenie.pedalgenieback.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+public class Shop extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "shop_id")
+    private Long shopId;
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    private String address;
+
+    @NotNull
+    private String contactNumber;
+
+    @NotNull
+    private int demoQuantityPerDay;
+
+    // businessHours
+
+    @Builder
+    public Shop(Long shopId, String name, String address, String contactNumber, int demoQuantityPerDay){
+        this.shopId=shopId;
+        this.name=name;
+        this.address=address;
+        this.contactNumber=contactNumber;
+        this.demoQuantityPerDay=demoQuantityPerDay;
+    }
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/repository/ShopRepository.java
@@ -4,6 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import com.pedalgenie.pedalgenieback.domain.shop.entity.Shop;
 
+import java.util.Optional;
+
 @Repository
 public interface ShopRepository extends JpaRepository<Shop, Long>{
+
+    Optional<Shop> findByShopname(final String shopname);
 }

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/repository/ShopRepository.java
@@ -1,0 +1,9 @@
+package com.pedalgenie.pedalgenieback.domain.shop.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import com.pedalgenie.pedalgenieback.domain.shop.entity.Shop;
+
+@Repository
+public interface ShopRepository extends JpaRepository<Shop, Long>{
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/subcategory/dto/FilterSubCategoryMetaResponse.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/subcategory/dto/FilterSubCategoryMetaResponse.java
@@ -1,0 +1,13 @@
+package com.pedalgenie.pedalgenieback.domain.subcategory.dto;
+
+public record FilterSubCategoryMetaResponse(
+        String keywords,
+        FilterSubCategoryResponse categories
+) {
+    public static FilterSubCategoryMetaResponse of(FilterSubCategoryResponse categoryResponse){
+        return new FilterSubCategoryMetaResponse(
+                "카테고리",
+                categoryResponse
+        );
+    }
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/subcategory/dto/FilterSubCategoryResponse.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/subcategory/dto/FilterSubCategoryResponse.java
@@ -1,0 +1,22 @@
+package com.pedalgenie.pedalgenieback.domain.subcategory.dto;
+
+import com.pedalgenie.pedalgenieback.domain.subcategory.entity.SubCategory;
+
+import java.util.List;
+
+public record FilterSubCategoryResponse(
+        List<SubCategoryResponse> subCategories
+) {
+    public static FilterSubCategoryResponse of(List<SubCategory> subCategories){
+        return new FilterSubCategoryResponse(
+                subCategories.stream().map(SubCategoryResponse::from).toList()
+        );
+    }
+
+    public record SubCategoryResponse(Long id, String name){
+        public static SubCategoryResponse from(SubCategory subCategory){
+            return new SubCategoryResponse(subCategory.getId(),
+                    subCategory.getName());
+        }
+    }
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/subcategory/entity/SubCategory.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/subcategory/entity/SubCategory.java
@@ -1,0 +1,35 @@
+package com.pedalgenie.pedalgenieback.domain.subcategory.entity;
+
+import com.pedalgenie.pedalgenieback.domain.category.entity.Category;
+import com.pedalgenie.pedalgenieback.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class SubCategory extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "subCategory_id")
+    private Long id;
+
+    @NotNull
+    private String name;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Builder
+    public SubCategory(Long id, String name, Category category){
+        this.id=id;
+        this.name=name;
+        this.category=category;
+
+    }
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/subcategory/repository/SubcategoryRepository.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/subcategory/repository/SubcategoryRepository.java
@@ -3,5 +3,8 @@ package com.pedalgenie.pedalgenieback.domain.subcategory.repository;
 import com.pedalgenie.pedalgenieback.domain.subcategory.entity.SubCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+
 public interface SubcategoryRepository extends JpaRepository<SubCategory,Long> {
+
+
 }

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/subcategory/repository/SubcategoryRepository.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/subcategory/repository/SubcategoryRepository.java
@@ -1,0 +1,7 @@
+package com.pedalgenie.pedalgenieback.domain.subcategory.repository;
+
+import com.pedalgenie.pedalgenieback.domain.subcategory.entity.SubCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubcategoryRepository extends JpaRepository<SubCategory,Long> {
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/global/exception/ErrorCode.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/global/exception/ErrorCode.java
@@ -35,6 +35,11 @@ public enum ErrorCode {
     NOT_EXISTS_MEMBER_NICKNAME(HttpStatus.NOT_FOUND, 404, "존재하지 않는 멤버 닉네임입니다."),
     NOT_EXISTS_MEMBER_EMAIL(HttpStatus.NOT_FOUND, 404, "존재하지 않는 멤버 이메일입니다."),
 
+    NOT_FOUND_SHOP_NAME(HttpStatus.NOT_FOUND, 404, "존재하지 않는 가게 이름입니다."),
+    NOT_FOUND_SUBCATEGORY(HttpStatus.NOT_FOUND,404,"존재하지 않는 서브 카테고리입니다."),
+    NOT_FOUND_PRODUCT(HttpStatus.NOT_FOUND,404,"존재하지 않는 상품입니다. "),
+    NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND,404,"존재하지 않는 카테고리입니다."),
+
     // 409
     ALREADY_REGISTERED_MEMBER_EMAIL(HttpStatus.CONFLICT, 409, "이미 가입된 이메일입니다."),
 

--- a/src/main/java/com/pedalgenie/pedalgenieback/global/jwt/JwtFilter.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/global/jwt/JwtFilter.java
@@ -6,7 +6,6 @@ import com.pedalgenie.pedalgenieback.domain.member.repository.MemberRepository;
 import com.pedalgenie.pedalgenieback.global.ResponseTemplate;
 import com.pedalgenie.pedalgenieback.global.exception.CustomException;
 import com.pedalgenie.pedalgenieback.global.exception.ErrorCode;
-import com.pedalgenie.pedalgenieback.global.jwt.refresh.RefreshToken;
 import com.pedalgenie.pedalgenieback.global.jwt.refresh.RefreshTokenRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,7 @@ spring:
       format_sql: true
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    dialect: org.hibernate.dialect.MySQL8Dialect  # 이 항목 추가
   security:
     oauth2:
       client:

--- a/src/test/java/com/pedalgenie/pedalgenieback/product/ProductRepositoryTest.java
+++ b/src/test/java/com/pedalgenie/pedalgenieback/product/ProductRepositoryTest.java
@@ -1,0 +1,146 @@
+package com.pedalgenie.pedalgenieback.product;
+
+import com.pedalgenie.pedalgenieback.domain.category.entity.Category;
+import com.pedalgenie.pedalgenieback.domain.category.repository.CategoryRepository;
+import com.pedalgenie.pedalgenieback.domain.product.entity.Product;
+import com.pedalgenie.pedalgenieback.domain.product.repository.ProductRepository;
+import com.pedalgenie.pedalgenieback.domain.shop.entity.Shop;
+import com.pedalgenie.pedalgenieback.domain.shop.repository.ShopRepository;
+import com.pedalgenie.pedalgenieback.domain.subcategory.entity.SubCategory;
+import com.pedalgenie.pedalgenieback.domain.subcategory.repository.SubcategoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DataJpaTest
+public class ProductRepositoryTest {
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private SubcategoryRepository subcategoryRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private ShopRepository shopRepository;
+
+    private SubCategory subCategory;
+    private Category category;
+    private Shop shop;
+
+    private Product product1;
+    private Product product2;
+    private Product product3;
+
+    @BeforeEach
+    void setUp(){
+        category = Category.builder()
+                .name("testCategory")
+                .build();
+
+        subCategory = SubCategory.builder()
+                .name("testSubCategory")
+                .category(category)
+                .build();
+
+        shop = Shop.builder()
+                .name("testShop")
+                .address("address")
+                .contactNumber("01021254947")
+                .demoQuantityPerDay(10)
+                .build();
+
+        product1 = Product.builder()
+                .name("name1")
+                .description("description1")
+                .rentPricePerDay(1000.0)
+                .rentQuantityPerDay(5)
+                .subCategory(subCategory)
+                .shop(shop)
+                .build();
+
+        product2 = Product.builder()
+                .name("name2")
+                .description("description2")
+                .rentPricePerDay(1000.0)
+                .rentQuantityPerDay(5)
+                .subCategory(subCategory)
+                .shop(shop)
+                .build();
+
+        product3 = Product.builder()
+                .name("name3")
+                .description("description3")
+                .rentPricePerDay(1000.0)
+                .rentQuantityPerDay(5)
+                .subCategory(subCategory)
+                .shop(shop)
+                .build();
+
+        // 테이블 간 저장 순서 유의
+        categoryRepository.save(category);
+        subcategoryRepository.save(subCategory);
+        shopRepository.save(shop);
+        productRepository.save(product1);
+        productRepository.save(product2);
+        productRepository.save(product3);
+
+    }
+
+    @Test
+    void 상품_조회_테스트(){
+        // given & when
+        final Product product1 = productRepository.findById(this.product1.getId())
+                .orElse(null);
+        final Product product2 = productRepository.findById(this.product2.getId())
+                .orElse(null);
+        final Product product3 = productRepository.findById(this.product3.getId())
+                .orElse(null);
+
+        assertSoftly(softly -> {
+            softly.assertThat(product1).isEqualTo(this.product1);
+            softly.assertThat(product2).isEqualTo(this.product2);
+            softly.assertThat(product3).isEqualTo(this.product3);
+
+        });
+    }
+
+    @Test
+    void 카테고리에_해당하는_모든_상품을_조회한다(){
+        //given & when
+        final List<Product> productList = productRepository.findAllBySubCategoryCategoryId(category.getId());
+
+        // then
+        assertSoftly(softly ->{
+            softly.assertThat(productList.size()).isEqualTo(3);
+            softly.assertThat(productList.get(0)).isEqualTo(product1);
+            softly.assertThat(productList.get(1)).isEqualTo(product2);
+            softly.assertThat(productList.get(2)).isEqualTo(product3);
+
+        });
+    }
+
+    @Test
+    void 서브카테고리에_해당하는_모든_상품을_조회한다(){
+        //given & when
+        final List<Product> productList = productRepository.findBySubCategoryId(subCategory.getId());
+
+        // then
+        assertSoftly(softly ->{
+            softly.assertThat(productList.size()).isEqualTo(3);
+            softly.assertThat(productList.get(0)).isEqualTo(product1);
+            softly.assertThat(productList.get(1)).isEqualTo(product2);
+            softly.assertThat(productList.get(2)).isEqualTo(product3);
+
+        });
+    }
+
+}

--- a/src/test/java/com/pedalgenie/pedalgenieback/product/ProductRepositoryTest.java
+++ b/src/test/java/com/pedalgenie/pedalgenieback/product/ProductRepositoryTest.java
@@ -56,31 +56,32 @@ public class ProductRepositoryTest {
                 .address("address")
                 .contactNumber("01021254947")
                 .demoQuantityPerDay(10)
+                .businessHours("9:00am-18:00pm")
                 .build();
 
         product1 = Product.builder()
                 .name("name1")
-                .description("description1")
                 .rentPricePerDay(1000.0)
                 .rentQuantityPerDay(5)
+                .price(10000.0)
                 .subCategory(subCategory)
                 .shop(shop)
                 .build();
 
         product2 = Product.builder()
                 .name("name2")
-                .description("description2")
                 .rentPricePerDay(1000.0)
                 .rentQuantityPerDay(5)
+                .price(10000.0)
                 .subCategory(subCategory)
                 .shop(shop)
                 .build();
 
         product3 = Product.builder()
                 .name("name3")
-                .description("description3")
                 .rentPricePerDay(1000.0)
                 .rentQuantityPerDay(5)
+                .price(10000.0)
                 .subCategory(subCategory)
                 .shop(shop)
                 .build();


### PR DESCRIPTION
## #️⃣ 연관된 이슈
 #3

---
## 📝 작업 내용
- 상품 관련 API 구현 
- 가게, 카테고리, 하위 카테고리 Repository 계층까지 구현 
- 공용 response Template, 공용 ErrorCode 적용

---
## 💬 리뷰 요구사항
- 상품 관련 JPA 쿼리가 필요하다면 `ProductRepository` 를 사용하시면 됩니다. 나머지 리포지토리는 커스텀 리포지토리입니다. 
---
## 🔗 레퍼런스
