### PR TITLE
[FEAT] 로그아웃, 회원 탈퇴 (카카오 연동 해제까지) 구현

### DIFF
--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/like/application/LikeService.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/like/application/LikeService.java
@@ -1,24 +1,35 @@
 package com.pedalgenie.pedalgenieback.domain.like.application;
 
+import com.pedalgenie.pedalgenieback.domain.like.dto.LikedShopDto;
 import com.pedalgenie.pedalgenieback.domain.like.entity.ProductLike;
 import com.pedalgenie.pedalgenieback.domain.like.entity.ShopLike;
 import com.pedalgenie.pedalgenieback.domain.like.repository.ProductLikeRepository;
 import com.pedalgenie.pedalgenieback.domain.like.repository.ShopLikeRepository;
 import com.pedalgenie.pedalgenieback.domain.member.entity.Member;
 import com.pedalgenie.pedalgenieback.domain.member.repository.MemberRepository;
+import com.pedalgenie.pedalgenieback.domain.product.dto.response.GetProductQueryResponse;
+import com.pedalgenie.pedalgenieback.domain.product.dto.response.ProductResponse;
 import com.pedalgenie.pedalgenieback.domain.product.entity.Product;
 import com.pedalgenie.pedalgenieback.domain.product.repository.ProductRepository;
+import com.pedalgenie.pedalgenieback.domain.productImage.application.dto.ProductImageDto;
 import com.pedalgenie.pedalgenieback.domain.shop.entity.Shop;
 import com.pedalgenie.pedalgenieback.domain.shop.repository.ShopRepository;
 import com.pedalgenie.pedalgenieback.global.exception.CustomException;
 import com.pedalgenie.pedalgenieback.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Tag(name = "Like api", description = "악기, 가게 좋아요 생성, 삭제, 조회 기능을 포함합니다.")
 public class LikeService {
 
     private final ProductLikeRepository productLikeRepository;
@@ -26,6 +37,7 @@ public class LikeService {
     private final ProductRepository productRepository;
     private final ShopRepository shopRepository;
     private final MemberRepository memberRepository;
+
 
     // 상품 좋아요 생성
     @Transactional
@@ -110,6 +122,26 @@ public class LikeService {
         // 좋아요 삭제
         shopLikeRepository.delete(shopLike);
     }
+
+    // 좋아요한 상품 목록 조회
+
+
+    // 좋아요한 가게 목록 조회
+    public List<LikedShopDto> getShopLikeList(Long memberId){
+        // 멤버 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_EXISTS_MEMBER_ID));
+        // 좋아요한 가게 목록 조회
+        List<Shop> likedShops = shopLikeRepository.findLikedShopsByMember(member);
+
+        return likedShops.stream()
+                .map(shop -> LikedShopDto.builder()
+                        .shopId(shop.getId())
+                        .shopName(shop.getShopname())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
 
     // 상품 좋아요 개수 조회
     public Long countProductLikes(Long productId) {

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/like/dto/LikedShopDto.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/like/dto/LikedShopDto.java
@@ -1,0 +1,11 @@
+package com.pedalgenie.pedalgenieback.domain.like.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LikedShopDto {
+    private Long shopId;
+    private String shopName;
+}

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/like/presentation/LikeController.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/like/presentation/LikeController.java
@@ -1,6 +1,7 @@
 package com.pedalgenie.pedalgenieback.domain.like.presentation;
 
 import com.pedalgenie.pedalgenieback.domain.like.application.LikeService;
+import com.pedalgenie.pedalgenieback.domain.like.dto.LikedShopDto;
 import com.pedalgenie.pedalgenieback.global.ResponseTemplate;
 import com.pedalgenie.pedalgenieback.global.jwt.AuthUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -8,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -53,5 +56,17 @@ public class LikeController {
 
         likeService.removeShopLike(shopId, memberId);
         return ResponseTemplate.createTemplate(HttpStatus.OK, true, "가게 좋아요 삭제 성공", null);
+    }
+
+    // 악기 좋아요 목록 조회
+
+
+    // 가게 좋아요 목록 조회
+    @GetMapping("/shops")
+    public ResponseEntity<ResponseTemplate<Object>> getShopLikeList(){
+        Long memberId = AuthUtils.getCurrentMemberId();
+
+        List<LikedShopDto> responseDto = likeService.getShopLikeList(memberId);
+        return ResponseTemplate.createTemplate(HttpStatus.OK, true, "가게 좋아요 목록 조회 성공", responseDto);
     }
 }

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/like/repository/ShopLikeRepository.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/like/repository/ShopLikeRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -17,6 +18,11 @@ public interface ShopLikeRepository extends JpaRepository<ShopLike, Long> {
     // 가게, 멤버를 기준으로 좋아요가 존재하는지 반환하는 메서드
     boolean existsByShopAndMember(Shop shop, Member member);
     Optional<ShopLike> findByShopAndMember(Shop shop, Member member);
+
+    // 회원이 좋아요 누른 상점 리스트 반환하는 메서드
+    @Query("SELECT sl.shop FROM ShopLike sl WHERE sl.member = :member")
+    List<Shop> findLikedShopsByMember(@Param("member") Member member);
+
 
 }
 

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/member/controller/MemberController.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.pedalgenie.pedalgenieback.domain.member.dto.MemberLoginRequestDto;
 import com.pedalgenie.pedalgenieback.domain.member.dto.MemberLoginResponseDto;
 import com.pedalgenie.pedalgenieback.domain.member.dto.MemberRegisterRequestDto;
 import com.pedalgenie.pedalgenieback.domain.member.dto.MemberResponseDto;
+import com.pedalgenie.pedalgenieback.domain.member.entity.MemberRole;
 import com.pedalgenie.pedalgenieback.domain.member.service.MemberService;
 import com.pedalgenie.pedalgenieback.global.ResponseTemplate;
 import com.pedalgenie.pedalgenieback.global.exception.CustomException;
@@ -82,5 +83,48 @@ public class MemberController {
         MemberResponseDto responseDto = memberService.getMemberInfo(memberId);
 
         return ResponseTemplate.createTemplate(HttpStatus.OK,true, "회원 조회 성공", responseDto);
+    }
+
+    // 로그아웃
+    @Operation(summary="로그아웃")
+    @PostMapping("/logout")
+    public ResponseEntity<ResponseTemplate<Object>> logout(HttpServletResponse response){
+        // 로그인한 memberId 가져오기
+        Long memberId = AuthUtils.getCurrentMemberId();
+
+        // 로그아웃 처리
+        memberService.logout(memberId);
+
+        // 쿠키에서 리프레시 토큰 삭제
+        Cookie refreshTokenCookie = new Cookie("refreshToken", null);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setHttpOnly(true);
+//        refreshTokenCookie.setSecure(true); https only 나중에 도메인 붙이고 처리
+        refreshTokenCookie.setMaxAge(0); // 즉시 만료
+        response.addCookie(refreshTokenCookie);
+
+        return ResponseTemplate.createTemplate(HttpStatus.OK,true, "로그아웃 성공", null);
+    }
+
+    // 회원 탈퇴
+    @Operation(summary="회원 탈퇴")
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<ResponseTemplate<MemberResponseDto>> withdraw(HttpServletResponse response){
+        // 로그인한 memberId 가져오기
+        Long memberId = AuthUtils.getCurrentMemberId();
+        String role = AuthUtils.getCurrentRole();
+
+        // 회원 탈퇴
+        memberService.withdraw(memberId, role);
+
+        // 쿠키에서 리프레시 토큰 삭제
+        Cookie refreshTokenCookie = new Cookie("refreshToken", null);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setHttpOnly(true);
+//        refreshTokenCookie.setSecure(true); https only 나중에 도메인 붙이고 처리
+        refreshTokenCookie.setMaxAge(0); // 즉시 만료
+        response.addCookie(refreshTokenCookie);
+
+        return ResponseTemplate.createTemplate(HttpStatus.OK,true, "회원 탈퇴 성공", null);
     }
 }

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/member/entity/Member.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/member/entity/Member.java
@@ -30,12 +30,16 @@ public class Member extends BaseTimeEntity {
 
     private String password; // 어드민, 사장님용
 
+    private Long oauthId; // 일반 고객용
+
     @Builder
-    public Member(Long memberId, String nickname, MemberRole memberRole, String email, String password){
+    public Member(Long memberId, String nickname, MemberRole memberRole, String email, String password, Long oauthId){
         this.memberId = memberId;
         this.nickname = nickname;
         this.memberRole = memberRole;
         this.email = email;
         this.password = password;
+        this.oauthId = oauthId;
     }
+
 }

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/member/service/MemberService.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/member/service/MemberService.java
@@ -13,7 +13,10 @@ import com.pedalgenie.pedalgenieback.global.jwt.CustomUserDetails;
 import com.pedalgenie.pedalgenieback.global.jwt.CustomUserDetailsService;
 import com.pedalgenie.pedalgenieback.global.jwt.TokenDto;
 import com.pedalgenie.pedalgenieback.global.jwt.TokenProvider;
+import com.pedalgenie.pedalgenieback.global.oauth.service.OAuthService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -22,15 +25,20 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MemberService {
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
     private final MemberRepository memberRepository;
     private final TokenProvider tokenProvider;
     private final CustomUserDetailsService customUserDetailsService;
     private final AuthenticationManager authenticationManager;
     private final PasswordEncoder passwordEncoder;
+    private final OAuthService oAuthService;
 
     // 자체 회원가입 메서드
     @Transactional
@@ -127,5 +135,37 @@ public class MemberService {
                 .role(member.getMemberRole().name())
                 .build();
     }
+    // 로그아웃 메서드
+    public void logout(Long memberId){
+        // 회원 조회 및 예외 처리
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_EXISTS_MEMBER_ID));
+        
+        // redis에서 리프레시 토큰 삭제
+        String key = "refreshToken:" + memberId;
+        String refreshToken = redisTemplate.opsForValue().get(key);
 
+        if (refreshToken != null) {
+            redisTemplate.delete(key);
+        } else {
+            throw new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+    }
+    // 회원 탈퇴 메서드
+    @Transactional
+    public void withdraw(Long memberId, String role) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_EXISTS_MEMBER_ID));
+
+        // 로그아웃 처리
+        logout(memberId);
+
+        // 일반 회원
+        if(role.equals("CUSTOMER")){
+            Long oauthId = member.getOauthId();
+            // 카카오 연동 끊기
+            oAuthService.unlinkKakao(oauthId);
+        }
+        // DB 변경 로직 추가 필요
+    }
 }

--- a/src/main/java/com/pedalgenie/pedalgenieback/global/config/SecurityConfig.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/global/config/SecurityConfig.java
@@ -72,7 +72,7 @@ public class SecurityConfig {
                 .formLogin(auth -> auth.disable()) // 기본 로그인 폼 비활성화
                 .httpBasic(HttpBasicConfigurer::disable) // 기본 HTTP 기본 인증 비활성화
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
+                .logout(logout -> logout.disable()) // 기본 로그아웃 비활성화
                 // 경로 권한 설정
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(ALLOWED_URIS.toArray(new String[0])).permitAll()

--- a/src/main/java/com/pedalgenie/pedalgenieback/global/exception/ErrorCode.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     KAKAO_LOGIN_FAILED(HttpStatus.BAD_REQUEST, 400, "카카오 로그인에 실패했습니다."),
     KAKAO_ACCESS_TOKEN_ERROR(HttpStatus.BAD_REQUEST, 400, "카카오 액세스 토큰을 가져오는데 실패했습니다."),
     KAKAO_USER_INFO_ERROR(HttpStatus.BAD_REQUEST, 400, "카카오 사용자 정보를 가져오는데 실패했습니다."),
+    KAKAO_UNLINK_FAILED(HttpStatus.BAD_REQUEST, 400, "카카오 연동 해제에 실패했습니다."),
     KAKAO_INVALID_CODE(HttpStatus.BAD_REQUEST, 400, "유효하지 않은 카카오 인가 코드입니다."),
 
     // 401

--- a/src/main/java/com/pedalgenie/pedalgenieback/global/oauth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/global/oauth/dto/KakaoUserInfo.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class KakaoUserInfo {
+    private final Long oauthId;
     private final String email;
     private final String nickname;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,11 +18,13 @@ spring:
   security:
     oauth2:
       client:
+        app-id: ${KAKAO_APP_ID}
         client-id: ${KAKAO_CLIENT_ID}
         redirect-uri: ${KAKAO_REDIRECT_URI}
       provider:
         token-uri: https://kauth.kakao.com/oauth/token
         user-info-uri: https://kapi.kakao.com/v2/user/me
+        unlink-uri: https://kapi.kakao.com/v1/user/unlink
 
 jwt:
   secret: ${JWT}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#10 

---
## 📝 작업 내용
- 로그아웃 API 구현
- 회원 탈퇴 API 일부 구현 

---
## 💬 리뷰 요구사항
회원과 연관 관계가 있는 엔티티 작업이 다 끝난 상황이 아니라, 개발 마무리 단계에서 DB 반영하려고 합니다.
회원 탈퇴의 경우 로그아웃 -> (카카오 회원) 연동 해제 -> 회원 DB 및 연관 관계 처리 과정을 거쳐야하는데, 회원과 연관 관계를 맺고 있는 엔티티들이 많아서 이를 어떻게 처리할지 조금 더 고민해보고 하려고 합니다.

1. .env 파일 업데이트
카카오 연동 해제 관련 시크릿값 업데이트 되었으니 노션의 env 파일로 업데이트 바랍니다.

2. 회원 필드 업데이트
회원 필드 일부 업데이트 되었으니, DB 확인바랍니다.

---
## 🔗 레퍼런스
