### PR TITLE
[FEAT] 좋아요한 상품 목록 조회 API, 일반 목록 조회시 좋아요 여부 필드 추가

### DIFF
--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/like/presentation/LikeController.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/like/presentation/LikeController.java
@@ -2,6 +2,7 @@ package com.pedalgenie.pedalgenieback.domain.like.presentation;
 
 import com.pedalgenie.pedalgenieback.domain.like.application.LikeService;
 import com.pedalgenie.pedalgenieback.domain.like.dto.LikedShopDto;
+import com.pedalgenie.pedalgenieback.domain.product.dto.response.ProductResponse;
 import com.pedalgenie.pedalgenieback.global.ResponseTemplate;
 import com.pedalgenie.pedalgenieback.global.jwt.AuthUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -59,7 +60,13 @@ public class LikeController {
     }
 
     // 악기 좋아요 목록 조회
+    @GetMapping("/products")
+    public ResponseEntity<ResponseTemplate<Object>> getProductLikeList(){
+        Long memberId = AuthUtils.getCurrentMemberId();
 
+        List<ProductResponse> responseDto = likeService.getProductLikeList(memberId);
+        return ResponseTemplate.createTemplate(HttpStatus.OK, true, "악기 좋아요 목록 조회 성공", responseDto);
+    }
 
     // 가게 좋아요 목록 조회
     @GetMapping("/shops")

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/like/repository/ProductLikeRepository.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/like/repository/ProductLikeRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ProductLikeRepository extends JpaRepository<ProductLike, Long> {
@@ -18,5 +19,12 @@ public interface ProductLikeRepository extends JpaRepository<ProductLike, Long> 
     boolean existsByProductAndMember(Product product, Member member);
     Optional<ProductLike> findByProductAndMember(Product product, Member member);
 
+    // memberId 기준으로 좋아요한 productId 목록 조회메서드
+    @Query("SELECT l.product.id FROM ProductLike l WHERE l.member.memberId = :memberId AND l.product.id IN :productIds")
+    List<Long> findLikedProductIdsByMember(@Param("memberId") Long memberId, @Param("productIds") List<Long> productIds);
+
+    // memberId 기준으로 좋아요한 product 목록 조회 메서드
+    @Query("SELECT l.product FROM ProductLike l WHERE l.member.memberId = :memberId")
+    List<Product> findLikedProductsByMember(@Param("memberId") Long memberId);
 }
 

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/like/repository/ShopLikeRepository.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/like/repository/ShopLikeRepository.java
@@ -23,6 +23,8 @@ public interface ShopLikeRepository extends JpaRepository<ShopLike, Long> {
     @Query("SELECT sl.shop FROM ShopLike sl WHERE sl.member = :member")
     List<Shop> findLikedShopsByMember(@Param("member") Member member);
 
-
+    // memberId를 기준으로 상점 좋아요 Id 리스트 반환하는 메서드
+    @Query("SELECT sl.shop.id FROM ShopLike sl WHERE sl.member.memberId = :memberId")
+    List<Long> findLikedShopIdsByMemberId(@Param("memberId") Long memberId);
 }
 

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/application/ProductQueryService.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/application/ProductQueryService.java
@@ -1,6 +1,7 @@
 package com.pedalgenie.pedalgenieback.domain.product.application;
 
 import com.pedalgenie.pedalgenieback.domain.category.entity.Category;
+import com.pedalgenie.pedalgenieback.domain.like.application.LikeService;
 import com.pedalgenie.pedalgenieback.domain.like.repository.ProductLikeRepository;
 import com.pedalgenie.pedalgenieback.domain.product.dto.request.FilterRequest;
 import com.pedalgenie.pedalgenieback.domain.product.dto.response.*;
@@ -30,6 +31,7 @@ public class ProductQueryService {
     private final SubcategoryRepository subcategoryRepository;
     private final ProductQueryRepositoryCustom productQueryRepository;
     private final ProductImageQueryService productImageQueryService;
+    private final LikeService likeService;
     private final ShopRepository shopRepository;
     private final ProductLikeRepository productLikeRepository;
 
@@ -67,9 +69,8 @@ public class ProductQueryService {
         List<ProductImageDto> productImages = productImageQueryService.getProductImages(id);
 
         // 로그인하지 않은 유저 처리
-        Boolean isLiked = (memberId == null)
-                ? null
-                : getLikedProductIds(memberId, List.of(id)).contains(id);
+        Boolean isLiked = (memberId != null) &&
+            likeService.isProductLiked(id, memberId) ? true: null;
 
         return GetProductResponse.of(product, productImages, isLiked);
     }

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/application/ProductQueryService.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/application/ProductQueryService.java
@@ -1,6 +1,7 @@
 package com.pedalgenie.pedalgenieback.domain.product.application;
 
 import com.pedalgenie.pedalgenieback.domain.category.entity.Category;
+import com.pedalgenie.pedalgenieback.domain.like.repository.ProductLikeRepository;
 import com.pedalgenie.pedalgenieback.domain.product.dto.request.FilterRequest;
 import com.pedalgenie.pedalgenieback.domain.product.dto.response.*;
 import com.pedalgenie.pedalgenieback.domain.product.entity.Product;
@@ -30,24 +31,25 @@ public class ProductQueryService {
     private final ProductQueryRepositoryCustom productQueryRepository;
     private final ProductImageQueryService productImageQueryService;
     private final ShopRepository shopRepository;
+    private final ProductLikeRepository productLikeRepository;
 
 
     // 전체, 상위 카테고리별 목록 조회(필터, 정렬, 서브 카테고리 옵션)
     public List<GetProductQueryResponse> getProductsByCategory(
             Category category,
-            FilterRequest request){
+            FilterRequest request) {
 
         return productQueryRepository.findPagingProducts(category, request);
 
     }
 
     // 이용 범위 옵션 조회
-    public FilterResponse getMetadataForFilter(){
+    public FilterResponse getMetadataForFilter() {
         return FilterResponse.of();
     }
 
     // 서브 카테고리 옵션 조회
-    public FilterSubCategoryResponse getMetaForSubCategory(Category category){
+    public FilterSubCategoryResponse getMetaForSubCategory(Category category) {
         List<SubCategory> subCategories = subcategoryRepository.findByCategory(category);
         return FilterSubCategoryResponse.of(subCategories);
     }
@@ -58,28 +60,51 @@ public class ProductQueryService {
     }
 
     // 상품 상세 조회
-    public GetProductResponse getProductResponse(Long id){
+    public GetProductResponse getProductResponse(Long id, Long memberId) {
         Product product = productRepository.findById(id)
-                .orElseThrow(()-> new CustomException(ErrorCode.NOT_FOUND_PRODUCT));
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_PRODUCT));
 
         List<ProductImageDto> productImages = productImageQueryService.getProductImages(id);
-        return GetProductResponse.of(product, productImages);
+
+        // 로그인하지 않은 유저 처리
+        Boolean isLiked = (memberId == null)
+                ? null
+                : getLikedProductIds(memberId, List.of(id)).contains(id);
+
+        return GetProductResponse.of(product, productImages, isLiked);
     }
 
-    // 상품 목록
-    public List<ProductResponse> getProductsByShop(Long shopId) {
+    // 매장에 속한 상품 목록 조회
+    public List<ProductResponse> getProductsByShop(Long shopId, Long memberId) {
 
         List<Product> products = productRepository.findByShopId(shopId);
 
+        // 좋아요한 상품 ID 리스트 조회
+        List<Long> likedProductIds = (memberId == null) ? List.of() : getLikedProductIds(memberId, products.stream().map(Product::getId).toList());
+
         // 조회한 상품들을 ProductResponse로 변환하여 반환
         List<ProductResponse> productResponses = products.stream()
-                .map(product -> ProductResponse.from(
-                        product,
-                        productImageQueryService.getFirstProductImage(product.getId())
-                ))
+                .map(product -> {
+                    Boolean isLiked = likedProductIds.contains(product.getId()) // 상품이 좋아요된 상품인지 체크
+                        ? true: null;
+                    return ProductResponse.from(
+                            product,
+                            productImageQueryService.getFirstProductImage(product.getId()),
+                            isLiked
+                    );
+                })
                 .toList();
 
         return productResponses;
     }
 
+    // 좋아요한 상품 id 목록 조회
+    public List<Long> getLikedProductIds(Long memberId, List<Long> productIds) {
+        if (productIds == null || productIds.isEmpty()) {
+            return List.of();
+        }
+        return productLikeRepository.findLikedProductIdsByMember(memberId, productIds);
+    }
+
 }
+

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/GetProductResponse.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/GetProductResponse.java
@@ -1,11 +1,13 @@
 package com.pedalgenie.pedalgenieback.domain.product.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.pedalgenie.pedalgenieback.domain.product.entity.Product;
 import com.pedalgenie.pedalgenieback.domain.productImage.application.dto.ProductImageDto;
 
 import java.util.List;
 
 // 상품 상세 조회 dto
+@JsonInclude(JsonInclude.Include.NON_NULL) // null인 필드 제외
 public record GetProductResponse(
         String name,
         String shopName,
@@ -15,10 +17,12 @@ public record GetProductResponse(
         Boolean isRentable,
         Boolean isPurchasable,
         Boolean isDemoable,
+
         // 상품 설명 텍스트, 이미지 추가
-        List<ProductImageDto> productImage
+        List<ProductImageDto> productImage,
+        Boolean isLiked
 ) {
-    public static GetProductResponse of(Product product, List<ProductImageDto> productImage){
+    public static GetProductResponse of(Product product, List<ProductImageDto> productImage, Boolean isLiked){
         return new GetProductResponse(
                 product.getName(),
                 product.getShop().getShopname(),
@@ -28,8 +32,8 @@ public record GetProductResponse(
                 product.getIsRentable(),
                 product.getIsPurchasable(),
                 product.getIsDemoable(),
-                productImage
-
+                productImage,
+                isLiked != null ? isLiked : null
         );
     }
 }

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/ProductResponse.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/ProductResponse.java
@@ -1,9 +1,11 @@
 package com.pedalgenie.pedalgenieback.domain.product.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.pedalgenie.pedalgenieback.domain.product.entity.Product;
 import com.pedalgenie.pedalgenieback.domain.productImage.application.dto.ProductImageDto;
 
 // api 응답 전용
+@JsonInclude(JsonInclude.Include.NON_NULL) // null인 필드 제외
 public record ProductResponse(
         Long id,
         String shopName,
@@ -12,10 +14,11 @@ public record ProductResponse(
         Boolean isRentable,
         Boolean isPurchasable,
         Boolean isDemoable,
-        String thumbnailImage // 여기 추가
+        String thumbnailImage, // 여기 추가
+        Boolean isLiked
 ) {
 
-    public static ProductResponse from(final Product product, ProductImageDto productImage){
+    public static ProductResponse from(final Product product, ProductImageDto productImage, Boolean isLiked){
         return new ProductResponse(
                 product.getId(),
                 product.getShop().getShopname(),
@@ -24,7 +27,8 @@ public record ProductResponse(
                 product.getIsRentable(),
                 product.getIsPurchasable(),
                 product.getIsDemoable(),
-                productImage != null ? productImage.imageUrl() : null
+                productImage != null ? productImage.imageUrl() : null,
+                isLiked !=null ? isLiked: null
         );
 
     }

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/application/ShopQueryService.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/application/ShopQueryService.java
@@ -1,5 +1,8 @@
 package com.pedalgenie.pedalgenieback.domain.shop.application;
 
+import com.pedalgenie.pedalgenieback.domain.like.application.LikeService;
+import com.pedalgenie.pedalgenieback.domain.like.entity.ShopLike;
+import com.pedalgenie.pedalgenieback.domain.like.repository.ShopLikeRepository;
 import com.pedalgenie.pedalgenieback.domain.product.dto.response.ProductResponse;
 import com.pedalgenie.pedalgenieback.domain.product.repository.ProductRepository;
 import com.pedalgenie.pedalgenieback.domain.product.application.ProductQueryService;
@@ -27,12 +30,18 @@ import java.util.stream.Collectors;
 public class ShopQueryService {
     private final ShopRepository shopRepository;
     private final ProductRepository productRepository;
+    private final ShopLikeRepository shopLikeRepository;
+    private final LikeService likeService;
     private final ProductQueryService productQueryService;
     private final ProductImageQueryService productImageQueryService;
 
     // 매장 목록 조회
-    public GetShopsResponses readShops(){
+    public GetShopsResponses readShops(Long memberId){
         List<Shop> shops = shopRepository.findAll();
+
+        List<Long> likedShopIds = (memberId != null) ?
+                shopLikeRepository.findLikedShopIdsByMemberId(memberId) :
+                List.of();
 
         Map<Shop, List<ShopProductResponse>> shopProductMap = shops.stream()
                 .collect(Collectors.toMap(
@@ -44,7 +53,7 @@ public class ShopQueryService {
                                 })
                                 .toList()
                 ));
-        return GetShopsResponses.from(shops, shopProductMap);
+        return GetShopsResponses.from(shops, shopProductMap, likedShopIds);
     }
 
     // 매장 상세 조회
@@ -52,9 +61,13 @@ public class ShopQueryService {
         Shop shop = shopRepository.findById(id)
                 .orElseThrow(()-> new CustomException(ErrorCode.NOT_EXISTS_SHOP_ID));
 
+        Boolean isLiked = (memberId != null) &&
+                likeService.isShopLiked(id, memberId) ? true: null;
+
+
         List<ProductResponse> products = productQueryService.getProductsByShop(id, memberId);
 
-        return GetShopResponse.from(shop, products);
+        return GetShopResponse.from(shop, isLiked, products);
 
     }
 

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/application/ShopQueryService.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/application/ShopQueryService.java
@@ -48,11 +48,11 @@ public class ShopQueryService {
     }
 
     // 매장 상세 조회
-    public GetShopResponse readShop(Long id){
+    public GetShopResponse readShop(Long id, Long memberId){
         Shop shop = shopRepository.findById(id)
                 .orElseThrow(()-> new CustomException(ErrorCode.NOT_EXISTS_SHOP_ID));
 
-        List<ProductResponse> products = productQueryService.getProductsByShop(id);
+        List<ProductResponse> products = productQueryService.getProductsByShop(id, memberId);
 
         return GetShopResponse.from(shop, products);
 

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/dto/response/GetShopResponse.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/dto/response/GetShopResponse.java
@@ -13,10 +13,10 @@ public record GetShopResponse (
         String contactNumber,
         String businessHours,
         String imageUrl,
+        Boolean isLiked,
         List<ProductResponse> products// 해당 매장의 상품 목록
-
 ) {
-    public static GetShopResponse from(Shop shop, List<ProductResponse> products){
+    public static GetShopResponse from(Shop shop, Boolean isLiked, List<ProductResponse> products){
 
         return new GetShopResponse(
                 shop.getShopname(),
@@ -24,6 +24,7 @@ public record GetShopResponse (
                 shop.getContactNumber(),
                 shop.getBusinessHours(),
                 shop.getImageUrl(),
+                isLiked != null ? isLiked : null,
                 products
         );
     }

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/dto/response/GetShopsResponses.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/dto/response/GetShopsResponses.java
@@ -9,11 +9,14 @@ import java.util.Map;
 public record GetShopsResponses(
         List<ShopResponse> shops
 ) {
-    public static GetShopsResponses from(List<Shop> shops, Map<Shop, List<ShopProductResponse>> shopProductMap){
+    public static GetShopsResponses from(List<Shop> shops, Map<Shop, List<ShopProductResponse>> shopProductMap,
+                                         List<Long> likedShopIds){
         List<ShopResponse> shopResponses = shops.stream()
                 .map(shop -> {
+                    Boolean isLiked = likedShopIds.contains(shop.getId())
+                            ? true: null;
                     List<ShopProductResponse> products = shopProductMap.get(shop); // 매장에 해당하는 상품 리스트 가져오기
-                    return ShopResponse.from(shop, products); //상품 리스트와 함께 ShopResponse 생성
+                    return ShopResponse.from(shop, isLiked, products); //상품 리스트와 함께 ShopResponse 생성
                 })
                 .toList();
 

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/dto/response/ShopResponse.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/dto/response/ShopResponse.java
@@ -1,20 +1,23 @@
 package com.pedalgenie.pedalgenieback.domain.shop.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.pedalgenie.pedalgenieback.domain.shop.entity.Shop;
 
 import java.util.List;
-
+@JsonInclude(JsonInclude.Include.NON_NULL) // null인 필드 제외
 public record ShopResponse(
         String shopname,
+
+        Boolean isLiked,
         // 해당 매장이 보유한 상품 리스트
         List<ShopProductResponse> products
 ) {
-    public static ShopResponse from(final Shop shop, List<ShopProductResponse> products){
+    public static ShopResponse from(final Shop shop, Boolean isLiked, List<ShopProductResponse> products){
 
         return new ShopResponse(
                 shop.getShopname(),
+                isLiked != null ? isLiked : null,
                 products // 이미 변환된 리스트
-
         );
     }
 }

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/presentation/ShopController.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/presentation/ShopController.java
@@ -22,9 +22,16 @@ public class ShopController {
 
     @Operation(summary = "매장 목록 조회")
     @GetMapping
-    public ResponseEntity<ResponseTemplate<GetShopsResponses>> getShops(){
+    public ResponseEntity<ResponseTemplate<GetShopsResponses>> getShops(@RequestHeader(value = "Authorization", required = false) String authorizationHeader){
 
-        GetShopsResponses getShopsResponses = shopQueryService.readShops();
+        Long memberId = null;
+
+        // 토큰이 있는 경우 memberId 추출
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            String token = authorizationHeader.substring(7);
+            memberId = tokenProvider.getMemberIdFromToken(token);
+        }
+        GetShopsResponses getShopsResponses = shopQueryService.readShops(memberId);
         return ResponseTemplate.createTemplate(HttpStatus.OK,true,"매장 목록 조회 성공", getShopsResponses);
 
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#4 
---
## 📝 작업 내용
- 좋아요한 상품 목록 조회 API 구현 (#4)
- 일반 상품, 상점 조회시 좋아요 여부 필드 추가 

---
## 💬 리뷰 요구사항

### **1. 수정 안된 것** 

@Operation(summary = "옵션에 따른 상품 목록 조회")
@PostMapping("/search")
 GetProductQueryResponse 엔티티에 아직 is_Liked 필드 안들어간 상태, 수정바람


### **2. 수정 된 것** 

**ProductController**

- 상품 상세조회, 목록 조회 API 중 토큰에서 memberId 추출 후 전달

**ProductQueryService**

좋아요한 상품 찾아서 필드에 넣는 로직 추가
- 상품 상세 조회
- 상품 목록 조회

**필드 추가된 dto**

- GetProductResponse
- ProductResponse 

참고) isLiked는 memberId가 null인 경우 반환하지 않음 

**ShopController**
- 매장 상세조회, 목록 조회 API 중 토큰에서 memberId 추출 후 전달

**ShopQueryService**
좋아요한 매장 찾아서 필드에 넣는 로직 추가
- 매장 상세 조회
- 매장 목록 조회

**필드 추가된 dto **
- ShopResponse
- GetShopResponse
- GetShopResponses
    - Service에서 좋아요한 매장 리스트 받아서, GetShopResponse 필드에 isLiked 추가


### 3. 참고사항
LikeService, ProductLikeRepository, ShopLikeRepository 등에

좋아요 조회 메서드가 많이 있으니, 필요한 경우 사용하거나 추가해도 괜찮습니다.

레포지토리에 있는 메서드들은 한 번에 전부 다 조회하는 쿼리를 사용한 메서드가 많고,

LikeService 아래 쪽 메서드들은 productId, memberId를 매칭해서 하나 조회하는 메서드 등이 있습니다.

명세서 수정된 것들은 노션에 CC 걸어두었으니 확인바랍니다. 

---
## 🔗 레퍼런스
