### PR TITLE
[FEAT}상품목록 조회 요청에 subCategoryNames 로 변경

### DIFF
--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/application/ProductQueryService.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/application/ProductQueryService.java
@@ -43,8 +43,10 @@ public class ProductQueryService {
             Long memberId,
             Pageable pageable) {
 
+
         Page<GetProductQueryResponse> products =productQueryRepository
                 .findPagingProducts(category, request, memberId, pageable);
+
 
         return products.stream()
                 .map(product -> {

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/request/FilterRequest.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/request/FilterRequest.java
@@ -11,7 +11,7 @@ public record FilterRequest(
         Boolean isDemoable,
         SortBy sortBy,
         @Size(max = 10, message = "카테고리는 최대 10개까지 선택할 수 있습니다.")
-        List<Long> subCategoryIds
+        List<String> subCategoryNames
 ) {
 
 
@@ -20,8 +20,8 @@ public record FilterRequest(
             Boolean isPurchasable,
             Boolean isDemoable,
             SortBy sortBy,
-            List<Long> subCategoryIds
+            List<String> subCategoryNames
     ){
-        return new FilterRequest(isRentable,isPurchasable,isDemoable, sortBy, subCategoryIds);
+        return new FilterRequest(isRentable,isPurchasable,isDemoable, sortBy, subCategoryNames);
     }
 }

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/presentation/ProductController.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/presentation/ProductController.java
@@ -42,7 +42,7 @@ public class ProductController {
             @RequestParam(required = false) Boolean isPurchasable,
             @RequestParam(required = false) Boolean isDemoable,
             @RequestParam(required = false) SortBy sortBy,
-            @RequestParam(required = false) List<Long> subCategoryIds,
+            @RequestParam(required = false) List<String> subCategoryNames,
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
             Pageable pageable
 
@@ -53,7 +53,7 @@ public class ProductController {
                 isPurchasable,
                 isDemoable,
                 sortBy,
-                subCategoryIds);
+                subCategoryNames);
 
         Long memberId = null;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
ex) #이슈번호, #이슈번호

---
## 📝 작업 내용
- 상품목록 조회에서 기존에는 subCategoryIds 를 요청 파라미터에 보내야했지만,  subCategoryNames 로 변경하였습니다. 

---
## 💬 리뷰 요구사항
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---
## 🔗 레퍼런스
