### PR TITLE
:sparkles: ProductResponse 의 필드명 imageUrl 로 변경

### DIFF
--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/ProductResponse.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/product/dto/response/ProductResponse.java
@@ -15,7 +15,7 @@ public record ProductResponse(
         Boolean isRentable,
         Boolean isPurchasable,
         Boolean isDemoable,
-        String thumbnailImage, // 여기 추가
+        String imageUrl, // thumbnailImage -> imageUrl 로 변경
         Boolean isLiked
 ) {
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
ex) #이슈번호, #이슈번호

---
## 📝 작업 내용
- ProductResponse 의 필드명 thumnailImage -> imageUrl 로 변경하였습니다. 
- 여기저기 쓰이는 dto 인데 프론트와 합의해서 전부 imageUrl 로 변경했다고 들어서 따로 dto 안 나누고 바로 필드명 바꿨습니다. 

---
## 💬 리뷰 요구사항
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---
## 🔗 레퍼런스
