### PR TITLE
[FIX] 좋아요 필드 리프레시 토큰 이용으로 로직 변경

### DIFF
--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/article/presentation/ArticleController.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/article/presentation/ArticleController.java
@@ -13,6 +13,7 @@ import com.pedalgenie.pedalgenieback.global.jwt.AuthUtils;
 import com.pedalgenie.pedalgenieback.global.jwt.TokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -89,18 +90,19 @@ public class ArticleController {
         return ResponseTemplate.createTemplate(HttpStatus.OK, true, "아티클 목록 조회 성공", articleList);
     }
 
-
     @Operation(summary="아티클 상세 조회")
     @GetMapping("/api/articles/{articleId}")
-    public ResponseEntity<ResponseTemplate<ArticleResponseDto>> getArticle(@PathVariable Long articleId,
-                                                                                 @RequestHeader(value = "Authorization", required = false) String authorizationHeader) {
+    public ResponseEntity<ResponseTemplate<ArticleResponseDto>> getArticle(@PathVariable Long articleId, HttpServletRequest request) {
         Long memberId = null;
+        // 쿠키에서 리프레시 토큰 추출 및 유효성 검증
+        String refreshToken = tokenProvider.getRefreshTokenFromRequest(request);
+        Boolean isValid = tokenProvider.isVaildRefreshToken(refreshToken);
 
-        // 토큰이 있는 경우 memberId 추출
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            String token = authorizationHeader.substring(7);
-            memberId = tokenProvider.getMemberIdFromToken(token);
+        // 리프레시 토큰이 유효할 때 memberId 추출
+        if(isValid) {
+            memberId = tokenProvider.getMemberIdFromToken(refreshToken);
         }
+
         // 아티클 상세 조회
         ArticleResponseDto responseDto = articleService.getArticle(articleId, memberId);
 

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/genre/presentation/GenreController.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/genre/presentation/GenreController.java
@@ -13,6 +13,7 @@ import com.pedalgenie.pedalgenieback.global.jwt.TokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -52,13 +53,15 @@ public class GenreController {
     @Operation(summary="장르 악기 상세 조회")
     @GetMapping("/api/products")
     public ResponseEntity<ResponseTemplate<List<ProductResponse>>> getGenreProduct(@RequestParam String genre,
-                                                                                     @RequestHeader(value = "Authorization", required = false) String authorizationHeader) {
+                                                                                   HttpServletRequest request) {
         Long memberId = null;
+        // 쿠키에서 리프레시 토큰 추출 및 유효성 검증
+        String refreshToken = tokenProvider.getRefreshTokenFromRequest(request);
+        Boolean isValid = tokenProvider.isVaildRefreshToken(refreshToken);
 
-        // 토큰이 있는 경우 memberId 추출
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            String token = authorizationHeader.substring(7);
-            memberId = tokenProvider.getMemberIdFromToken(token);
+        // 리프레시 토큰이 유효할 때 memberId 추출
+        if(isValid) {
+            memberId = tokenProvider.getMemberIdFromToken(refreshToken);
         }
 
         List<ProductResponse> responseDtos = genreService.getGenreProduct(genre, memberId);

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/presentation/ShopController.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/shop/presentation/ShopController.java
@@ -11,6 +11,7 @@ import com.pedalgenie.pedalgenieback.domain.shop.dto.response.ShopCreateResponse
 import com.pedalgenie.pedalgenieback.global.ResponseTemplate;
 import com.pedalgenie.pedalgenieback.global.jwt.TokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,14 +29,15 @@ public class ShopController {
 
     @Operation(summary = "매장 목록 조회")
     @GetMapping("/shops")
-    public ResponseEntity<ResponseTemplate<GetShopsResponses>> getShops(@RequestHeader(value = "Authorization", required = false) String authorizationHeader){
-
+    public ResponseEntity<ResponseTemplate<GetShopsResponses>> getShops(HttpServletRequest request){
         Long memberId = null;
+        // 쿠키에서 리프레시 토큰 추출 및 유효성 검증
+        String refreshToken = tokenProvider.getRefreshTokenFromRequest(request);
+        Boolean isValid = tokenProvider.isVaildRefreshToken(refreshToken);
 
-        // 토큰이 있는 경우 memberId 추출
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            String token = authorizationHeader.substring(7);
-            memberId = tokenProvider.getMemberIdFromToken(token);
+        // 리프레시 토큰이 유효할 때 memberId 추출
+        if(isValid) {
+            memberId = tokenProvider.getMemberIdFromToken(refreshToken);
         }
         GetShopsResponses getShopsResponses = shopQueryService.readShops(memberId);
         return ResponseTemplate.createTemplate(HttpStatus.OK,true,"매장 목록 조회 성공", getShopsResponses);
@@ -43,17 +45,16 @@ public class ShopController {
     }
     @Operation(summary = "매장 상세 조회")
     @GetMapping("/shops/{id}")
-    public ResponseEntity<ResponseTemplate<GetShopResponse>> getShopDetails(@PathVariable Long id,
-                                                                            @RequestHeader(value = "Authorization", required = false) String authorizationHeader){
-
+    public ResponseEntity<ResponseTemplate<GetShopResponse>> getShopDetails(@PathVariable Long id, HttpServletRequest request){
         Long memberId = null;
+        // 쿠키에서 리프레시 토큰 추출 및 유효성 검증
+        String refreshToken = tokenProvider.getRefreshTokenFromRequest(request);
+        Boolean isValid = tokenProvider.isVaildRefreshToken(refreshToken);
 
-        // 토큰이 있는 경우 memberId 추출
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            String token = authorizationHeader.substring(7);
-            memberId = tokenProvider.getMemberIdFromToken(token);
+        // 리프레시 토큰이 유효할 때 memberId 추출
+        if(isValid) {
+            memberId = tokenProvider.getMemberIdFromToken(refreshToken);
         }
-
         GetShopResponse response = shopQueryService.readShop(id, memberId);
         return ResponseTemplate.createTemplate(HttpStatus.OK, true, "매장 상세 조회 성공", response);
 

--- a/src/main/java/com/pedalgenie/pedalgenieback/global/jwt/JwtFilter.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/global/jwt/JwtFilter.java
@@ -58,7 +58,7 @@ public class JwtFilter extends OncePerRequestFilter {
         } catch (CustomException e) {
             // 엑세스 토큰 만료시 리프레시 토큰으로 엑세스토큰 재발급
             if (e.getErrorCode() == ErrorCode.TOKEN_EXPIRED) {
-                String refreshToken = getRefreshTokenFromRequest(request);
+                String refreshToken = tokenProvider.getRefreshTokenFromRequest(request);
                 
                 // 리프레시 토큰이 없는 경우 예외 처리
                 if (refreshToken == null || refreshToken.trim().isEmpty()) {
@@ -126,8 +126,7 @@ public class JwtFilter extends OncePerRequestFilter {
     }
 
 
-
-    // 요청 헤더에서 엑세스 을 추출하는 메서드
+    // 요청 헤더에서 엑세스 토큰을 추출하는 메서드
     private String getTokenFromRequest(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
@@ -136,16 +135,4 @@ public class JwtFilter extends OncePerRequestFilter {
         return null;
     }
 
-    // 쿠키에서 리프레시 토큰 추출하는 메서드
-    private String getRefreshTokenFromRequest(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if ("refreshToken".equals(cookie.getName())) {
-                    return cookie.getValue();
-                }
-            }
-        }
-        return null;
-    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
ex) #이슈번호, #이슈번호

---
## 📝 작업 내용
좋아요 필드 포함한 일반 API 에서 엑세스 토큰이 아닌 리프레시 토큰을 이용하여 회원 아이디를 조회하고, 좋아요 여부 확인하는 것으로 로직을 바꿨습니다. 

- [x]  아티클 상세 조회 `/api/articles/{articleId}`
- [x]  장르별 악기 상세 조회 `/api/products?genre={genre}`
- [x]  악기 목록 조회 `/api/products/search?category=GUITAR&isRentable=true&isPurchasable=true&isDemoable=true&sortBy=RECENT&subCategoryIds=16`
- [x]  상품 상세 조회 `/api/products/{productId}`
- [x]  매장 목록 조회 `/api/shops`
- [x]  매장 상세 조회 `/api/shops/{shopId}`
- [x]  검색 `/api/search?keyword=기타`

---
## 💬 리뷰 요구사항
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---
## 🔗 레퍼런스
