### PR TITLE
[FEAT] sentry 적용 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,11 @@
 
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.4'
 	id 'io.spring.dependency-management' version '1.1.6'
 }
+
 
 group = 'com.pedalgenie'
 version = '0.0.1-SNAPSHOT'
@@ -75,6 +77,11 @@ dependencies {
 
 	implementation 'software.amazon.awssdk:s3:2.20.121'
 	implementation 'software.amazon.awssdk:url-connection-client:2.20.121'
+
+	// sentry
+	// 아래 두 라이브러리는 버전을 통일해서 사용하길 권장
+	implementation 'io.sentry:sentry-spring-boot-starter-jakarta:7.20.0'
+	implementation 'io.sentry:sentry-jdbc:7.20.0'
 
 }
 

--- a/src/main/java/com/pedalgenie/pedalgenieback/domain/available/application/AvailableTimeService.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/domain/available/application/AvailableTimeService.java
@@ -43,6 +43,7 @@ public class AvailableTimeService {
     public void refreshAvailableTimes() {
         // 기존 데이터 삭제
         availableTimeRepository.deleteAll();
+        log.info("디비 삭제 후 남아있는 데이터 개수: {}", availableTimeRepository.count());
 
         // 대여 가능한 상품 조회
         List<Product> rentableProducts = productRepository.findAllByIsRentableTrue();
@@ -72,6 +73,7 @@ public class AvailableTimeService {
         Product product = getProduct(productId);
         Long shopId = product.getShop().getId();
         LocalDate today = LocalDate.now();
+        log.info("오늘 날짜: {}", today);
 
         // 기존 데이터 조회
         List<AvailableDateTime> existingAvailableTimes = availableTimeRepository.findByProductId(productId);
@@ -80,6 +82,7 @@ public class AvailableTimeService {
         // 28일간 예약 데이터 생성
         for (int i = 1; i <= 28; i++) {
             LocalDate targetDate = today.plusDays(i);
+            log.info("생성되는 예약 날짜: {}", targetDate);
 
             // ShopHours 조회
             ShopHours shopHours = timeService.determineShopHours(shopId, targetDate);

--- a/src/main/java/com/pedalgenie/pedalgenieback/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pedalgenie/pedalgenieback/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.pedalgenie.pedalgenieback.global.exception;
 
 import com.pedalgenie.pedalgenieback.global.ResponseTemplate;
+import io.sentry.Sentry;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -11,6 +12,9 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ResponseTemplate<Object>> handleCustomException(CustomException exception) {
         ErrorCode errorCode = exception.getErrorCode();
+
+        // sentry 에 예외 정보 전송
+        Sentry.captureException(exception);
 
         return ResponseTemplate.createTemplate(
                 errorCode.getHttpStatus(),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,3 +55,9 @@ holiday-api:
   uri: ${HOLIDAY_API_URI}
 
 domain: ${DOMAIN}
+
+sentry:
+  dsn: ${SENTRY_DSN}
+  # Set traces-sample-rate to 1.0 to capture 100% of transactions for tracing.
+  # We recommend adjusting this value in production.
+  traces-sample-rate: 1.0

--- a/src/test/java/com/pedalgenie/pedalgenieback/sentryTest.java
+++ b/src/test/java/com/pedalgenie/pedalgenieback/sentryTest.java
@@ -1,0 +1,20 @@
+package com.pedalgenie.pedalgenieback;
+
+
+
+import java.lang.Exception;
+import io.sentry.Sentry;
+import org.junit.jupiter.api.Test;
+
+
+public class sentryTest {
+
+        @Test
+        void testSentryExceptionCapture() {
+        try {
+            throw new Exception("This is a test.");
+        } catch (Exception e) {
+            Sentry.captureException(e);
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
ex) #이슈번호, #이슈번호

---
## 📝 작업 내용
- 실시간 에러 추적을 위해 sentry 를 적용해보았습니당. 
- 이런 식으로 디테일한 에러를 확인할 수 있어요. 
- 인스턴스 중지되어 있어서 포스트맨으로 대여 상세 조회를 테스트해 본 건데, 실제 사용 중인 애플리케이션이라면 에러가 발생한 브라우저, 디바이스 환경 등 더 다양하게 트래킹할 수 있다고 하네요! 쿼리 정보 수집 기능도 있다고 하는데, 다음에 또 pr 올려볼게요 하하 
<img width="1297" alt="스크린샷 2025-02-05 오전 6 26 36" src="https://github.com/user-attachments/assets/4a047f7b-eacd-4e51-88c5-baf5bc221b3b" />
<img width="1297" alt="스크린샷 2025-02-05 오전 6 22 05" src="https://github.com/user-attachments/assets/de182bdd-6e56-4ff2-b2fe-77d333860297" />

---
## 💬 리뷰 요구사항
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---
## 🔗 레퍼런스

[sentry_레퍼런스](https://velog.io/@da_na/Error-Monitoring-백엔드-에러-모니터링-시스템-Sentry-도입기#1-sentry에-로그인-한-후에-새로운-프로젝트-생성하기)
