### PR TITLE
[FIX] gRPC 경로 오류 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,22 +133,22 @@ tasks.named('test') {
 	useJUnitPlatform()
 }
 
-/*
- * queryDSL 설정 추가
- */
 
-def generated = 'build/generated'
+
+def generated = 'build/generated/querydsl'
+def grpcGenerated = 'build/generated/source/proto/main/grpc'
 
 tasks.withType(JavaCompile) {
 	options.generatedSourceOutputDirectory = file(generated)
 }
 
 sourceSets {
-	main.java.srcDirs += [generated]
+	main.java.srcDirs += [generated,grpcGenerated]
 }
 
 clean {
 	delete file(generated)
+	delete file(grpcGenerated)
 }
 
 

--- a/src/main/proto/available.proto
+++ b/src/main/proto/available.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 option java_package = "com.pedalgenie.pedalgenieback.domain.available.grpc";
-option java_outer_classname = "AvailableProto";
+option java_outer_classname = "AvailableTimeServiceProto";
 
 
 service AvailableTimeService{


### PR DESCRIPTION
## #️⃣ 연관된 이슈
ex) #이슈번호, #이슈번호

---
## 📝 작업 내용

- improt 경로 오류가 있어서 빌드에 실패하였습니다. querydsl 의 Q 엔티티 생성 경로와 겹치는 문제가 있을 듯하여 grpc 경로를 gradle 에서 직접 지정해주었습니다. 
`def grpcGenerated = 'build/generated/source/proto/main/grpc'
`
`import com.pedalgenie.pedalgenieback.domain.available.grpc.AvailableTimeServiceGrpc;
`

---
## 💬 리뷰 요구사항
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---
## 🔗 레퍼런스
